### PR TITLE
Adding aws region to vpc module for successful testing in terratest

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.7.0"


### PR DESCRIPTION
The Terratest Go file would fail due to not setting a region in AWS. From this, I added a couple lines in the `main.tf` file to include an `"aws"` provider and a region using `var.aws_region` referenced from the `variables.tf` file.